### PR TITLE
fix slotsmgrt-exec-wrapper command

### DIFF
--- a/src/pika_migrate_thread.cc
+++ b/src/pika_migrate_thread.cc
@@ -688,7 +688,7 @@ int PikaMigrateThread::ReqMigrateOne(const std::string &key, std::shared_ptr<Slo
 
   if (slot_id != slot_id_) {
     LOG(WARNING) << "PikaMigrateThread::ReqMigrateOne Slot : " << slot_id << " is not the migrating slot:" << slot_id_;
-    return -1;
+    return -2;
   }
 
   // if the migrate thread exit, start it

--- a/src/pika_slot_command.cc
+++ b/src/pika_slot_command.cc
@@ -1638,11 +1638,15 @@ void SlotsMgrtExecWrapperCmd::DoInitial() {
   return;
 }
 
+// return 0 means key not exist or key is not migrating
+// return 1 means key is migrating
+// return -1 means something wrong
 void SlotsMgrtExecWrapperCmd::Do(std::shared_ptr<Slot> slot) {
   res_.AppendArrayLen(2);
   int ret = g_pika_server->SlotsMigrateOne(key_, slot);
   switch (ret) {
-    case 0:
+    case 0 :
+    case -2:
       res_.AppendInteger(0);
       res_.AppendInteger(0);
       return;


### PR DESCRIPTION
change the return value of  slotsmgrt-exec-wrapper command:
1. return 0 means key not exist or key is not migrating
2. return 1 means key is migrating
3. return -1 means something wrong